### PR TITLE
Add prev feature to the occurrence

### DIFF
--- a/src/pyawscron/awscron.py
+++ b/src/pyawscron/awscron.py
@@ -144,7 +144,27 @@ class AWSCron:
 
     @staticmethod
     def get_prev_n_schedule(n, from_date, cron):
-        raise NotImplemented("WIP..")
+        """
+        Returns a list with the n prev datetime(s) that match the aws cron expression 
+        from the provided start date.
+
+        :param n: Int of the n next datetime(s)
+        :param from_date: datetime with the start date
+        :param cron: str of aws cron to be parsed
+        :return: list of datetime objects
+        """
+        schedule_list = list()
+        if not isinstance(from_date, datetime.datetime):
+            raise ValueError("Invalid from_date. Must be of type datetime.dateime" \
+                             " and have tzinfo = datetime.timezone.utc")
+        else:
+            cron_iterator = AWSCron(cron)
+            for i in range(n):
+                from_date = cron_iterator.occurrence(from_date).prev()
+                schedule_list.append(from_date)
+
+            return schedule_list
+
 
     @staticmethod
     def get_all_schedule_bw_dates(from_date, to_date, cron, exclude_ends=False):

--- a/src/pyawscron/commons.py
+++ b/src/pyawscron/commons.py
@@ -27,6 +27,20 @@ class Commons:
                 return i
         return None
 
+
+    @staticmethod
+    def array_find_last(sequence, function):
+        """
+        Static method c <= (current_minute if is_same_date and hour == current_hour else 0)
+        """
+        # Using reversed as an iterator to give an iterator to iterate upon 
+        # instead of fully reversing the list that will utilize lot of space.
+        for seq in reversed(sequence):
+            if function(seq) == True:
+                return seq
+        return None
+
+
     @staticmethod
     def get_days_of_month_from_days_of_week(year, month, days_of_week):
         days_of_month = []

--- a/tests/helper_method_tests.py
+++ b/tests/helper_method_tests.py
@@ -60,3 +60,50 @@ class NextTestCase(unittest.TestCase):
         self.assertEqual(str(expected_list), str(result))
 
 
+    def test_get_prev_n_schedule_1(self):
+        """Testing - retrieve n number of datetimes before start date  when aws cron expressing is set to
+           run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           Where start datetime is 8/7/2021 11:50:57 UTC
+        :return:
+        """
+        expected_list = [datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 11, 23, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 10, 46, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 10, 23, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 10, 0, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 9, 46, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 9, 23, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 9, 0, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc)]
+
+        from_dt = datetime.datetime(2021, 8, 7, 11, 50, 57, tzinfo=datetime.timezone.utc)
+        result = AWSCron.get_prev_n_schedule(10, from_dt, '0/23 * * * ? *')
+        self.assertEqual(str(expected_list), str(result))
+
+
+    def test_get_prev_n_schedule_2(self):
+        """Testing - retrieve n number of datetimes before start date when aws cron expressing is set to
+           run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC)
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           Where start datetime is 8/16/2021 8:50:57 UTC
+        :return:
+        """
+        expected_list = [datetime.datetime(2021, 8, 16, 8, 45, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 40, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 35, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 30, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 25, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 20, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 15, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 10, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 5, tzinfo=datetime.timezone.utc),
+                         datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc)]
+
+        from_dt = datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc)
+        result = AWSCron.get_prev_n_schedule(10, from_dt, '0/5 8-17 ? * MON-FRI *')
+        self.assertEqual(str(expected_list), str(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/next_tests.py
+++ b/tests/next_tests.py
@@ -244,3 +244,7 @@ class NextTestCase(unittest.TestCase):
             results.append(str(dt))
             print(f"Result: {dt}\tExpected: {expected}\n")
             self.assertEqual(expected, str(dt))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added prev method implementation for occurrence as well as test fixtures for prev_n_schedule check.

```
from_dt = datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc)
result = AWSCron.get_prev_n_schedule(10, from_dt, '0/5 8-17 ? * MON-FRI *')
print(result)

# Output

[datetime.datetime(2021, 8, 16, 8, 45, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 40, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 35, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 30, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 25, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 20, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 15, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 10, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 5, tzinfo=datetime.timezone.utc),
 datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc)]

```