### PR TITLE
Update to the get_days_of_month_from_days_of_week function

### DIFF
--- a/src/pyawscron/commons.py
+++ b/src/pyawscron/commons.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 from dateutil.relativedelta import relativedelta
+import calendar
 
 class Commons:
 
@@ -45,7 +46,8 @@ class Commons:
     def get_days_of_month_from_days_of_week(year, month, days_of_week):
         days_of_month = []
         index = 0 # only for "#" use case
-        for i in range(1, 31 + 1, 1):
+        no_of_days_in_month = calendar.monthrange(year,month)[1]
+        for i in range(1, no_of_days_in_month + 1, 1):
             this_date = datetime.datetime(year, month, i, tzinfo=datetime.timezone.utc)
             # already after last day of month
             if this_date.month != month:

--- a/tests/parse_tests.py
+++ b/tests/parse_tests.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import datetime
 from src.pyawscron import AWSCron
 
 
@@ -214,6 +215,30 @@ class ParseCronTestCase(unittest.TestCase):
         self.assertEqual(expected["months"], cron_obj.months)
         self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
         self.assertEqual(expected["years"], cron_obj.years)
+
+    def test_cron_expressions10(self):
+        """
+        Tested changes to get_days_of_month_from_days_of_week(), where the year rolls over and the month rolls over into a month that has less than 31 days.
+        """
+        cron_str = '0 9 ? * 2 *'
+        expected_list= ['2022-01-03 09:00:00+00:00',
+                        '2022-01-10 09:00:00+00:00',
+                        '2022-01-17 09:00:00+00:00',
+                        '2022-01-24 09:00:00+00:00',
+                        '2022-01-31 09:00:00+00:00',
+                        '2022-02-07 09:00:00+00:00',
+                        '2022-02-14 09:00:00+00:00',
+                        '2022-02-21 09:00:00+00:00',
+                        '2022-02-28 09:00:00+00:00',
+                        '2022-03-07 09:00:00+00:00'
+                        ]
+        cron = AWSCron(cron_str)
+        dt = datetime.datetime(2021, 12, 31, 21, 0, 0, tzinfo=datetime.timezone.utc)
+        self.print_cron_results(cron_str, cron)                        
+        results = []        
+        for expected in expected_list:
+            dt = cron.occurrence(dt).next()
+            self.assertEqual(expected, str(dt))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was a loop in the function get_days_of_month_from_days_of_week function which caused a ValueError when the months did not have the hard coded 31 days consistently.  For example, going from January to February (31 to 28), you would encounter an error with the number of days in the second month, Feb.  The change we request to be added would no longer hard code the 31 for each month but change the value to a parameter based on the month that was being considered.  We also wrote a test that rolled through three months: Jan, Feb, March to test the change to the code while not breaking the other tests that are in the directory.