### PR TITLE
fix: Undeclared dependency

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,25 +13,23 @@ on:
     types: [published]
 
 jobs:
-  deploy-to-pytest:
+  deploy-to-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install build
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install build
       - name: Build package
         run: |
-          echo "__version__ = '$(git describe --tags)'" > src/pyawscron/version.py
           python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@1.5.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/.github/workflows/python-pyawscron.yml
+++ b/.github/workflows/python-pyawscron.yml
@@ -20,16 +20,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install flake8 pytest
+          python -m pip install .
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-python-dateutil~=2.8.1
-setuptools~=40.6.2

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,28 @@
-import setuptools
-import os
-
-
-version = {}
-with open(os.path.abspath("src"+os.path.sep+"pyawscron"+os.path.sep+"version.py")) as fp:
-    exec(fp.read(), version)
-
-try:
-    assert "." in version['__version__']
-except AssertionError:
-    raise AssertionError("Failed to obtain version.")
+from setuptools import find_packages, setup
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-setuptools.setup(
-    name="pyawscron",
-    version=version['__version__'],
-    author="Michael Martin",
-    author_email="pitchblack408@gmail.com",
-    description="An AWS Cron Parser",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/pitchblack408/pyawscron",
-    project_urls={
-        "Bug Tracker": "https://github.com/pitchblack408/pyawscron/issues",
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-    ],
-    package_dir={"": "src"},
-    packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.6",
-)
+if __name__ == "__main__":
+    setup(
+        name="pyawscron",
+        version="1.0.4",
+        author="Michael Martin",
+        author_email="pitchblack408@gmail.com",
+        description="An AWS Cron Parser",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/pitchblack408/pyawscron",
+        project_urls={
+            "Bug Tracker": "https://github.com/pitchblack408/pyawscron/issues",
+        },
+        classifiers=[
+            "Programming Language :: Python :: 3",
+            "License :: OSI Approved :: BSD License",
+            "Operating System :: OS Independent",
+        ],
+        package_dir={"": "src"},
+        packages=find_packages(where="src"),
+        python_requires=">=3.6",
+        install_requires=["python-dateutil~=2.8.1"],
+    )


### PR DESCRIPTION
Closes #48 

This PR moves the dependency on `python-dateutil` out of `requirements.txt` and into `setup.py` where pip can read it, thus solving a missing module error on install of the package.

I've also done some additional minor related tweaks such as:

* Updating the github actions (e.g. `actions/checkout`) to their latest versions
* Tweaking the workflows to work with the new method of specifying requirements