### PR TITLE
Support for timezones

### DIFF
--- a/src/pyawscron/awscron.py
+++ b/src/pyawscron/awscron.py
@@ -41,10 +41,8 @@ class AWSCron:
         self.rules = cron.split(' ')
         self.__parse()
 
-    def occurrence(self, utc_datetime):
-        if utc_datetime.tzinfo is None or utc_datetime.tzinfo != datetime.timezone.utc:
-            raise Exception("Occurrence utc_datetime must have tzinfo == datetime.timezone.utc")
-        return Occurrence(self, utc_datetime)
+    def occurrence(self, any_datetime):
+        return Occurrence(self, any_datetime)
 
     def __str__(self):
         return f"cron({self.cron})"
@@ -132,8 +130,7 @@ class AWSCron:
         """
         schedule_list = list()
         if not isinstance(from_date, datetime.datetime):
-            raise ValueError("Invalid from_date. Must be of type datetime.dateime" \
-                             " and have tzinfo = datetime.timezone.utc")
+            raise ValueError("Invalid from_date. Must be of type datetime.dateime")
         else:
             cron_iterator = AWSCron(cron)
             for i in range(n):
@@ -156,8 +153,7 @@ class AWSCron:
         """
         schedule_list = list()
         if not isinstance(from_date, datetime.datetime):
-            raise ValueError("Invalid from_date. Must be of type datetime.dateime" \
-                             " and have tzinfo = datetime.timezone.utc")
+            raise ValueError("Invalid from_date. Must be of type datetime.dateime")
         else:
             cron_iterator = AWSCron(cron)
             for i in range(n):
@@ -174,8 +170,8 @@ class AWSCron:
         If the cron expression matches either 'from_date' and/or 'to_date',
         those times will be returned as well unless 'exclude_ends=True' is passed.
 
-        :param from_date: datetime object from where the schedule will start with tzinfo in utc.
-        :param to_date: datetime object to where the schedule will end with tzinfo in utc.
+        :param from_date: datetime object from where the schedule will start.
+        :param to_date: datetime object to where the schedule will end.
         :param cron: str of aws cron to be parsed
         :param exclude_ends: bool defaulted to false to not exclude the end date
         :return: list of datetime objects
@@ -189,9 +185,9 @@ class AWSCron:
                              "  {0} != {1}".format(type(from_date), type(to_date)))
         
         elif (not isinstance(from_date, datetime.datetime) or 
-            (from_date.tzinfo != datetime.timezone.utc)):
+            (from_date.tzinfo != to_date.tzinfo)):
             raise ValueError("Invalid from_date and to_date. Must be of type datetime.dateime" \
-                             " and have tzinfo = datetime.timezone.utc")
+                             " and the same tzinfo")
         else:
             schedule_list = []
             cron_iterator = AWSCron(cron)

--- a/tests/next_tz_tests.py
+++ b/tests/next_tz_tests.py
@@ -1,0 +1,391 @@
+
+# -*- coding: utf-8 -*-
+
+import unittest
+import datetime
+from src.pyawscron import AWSCron
+from dateutil import tz
+
+class NextTestCase(unittest.TestCase):
+
+
+    def setUp(self):
+        print(self._testMethodName)
+
+
+    def tearDown(self):
+        pass
+
+    def test_generate_multiple_next_occurences1(self):
+        """At 23, 24, and 25 minutes past the hour, at 05:00 PM and 06:00 PM,
+           on day 25 of the month, every 4 months, March through December,
+           only in 2020, 2021, 2023, and 2028
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           / ==>> This character is used to specify increments.
+        :return:
+        """
+        cron = '23,24,25 17,18 25 MAR/4 ? 2020,2021,2023,2028'
+        expected_list= ['2020-07-25 17:23:00+01:00',
+                        '2020-07-25 17:24:00+01:00',
+                        '2020-07-25 17:25:00+01:00',
+                        '2020-07-25 18:23:00+01:00',
+                        '2020-07-25 18:24:00+01:00',
+                        '2020-07-25 18:25:00+01:00',
+
+                        '2020-11-25 17:23:00+00:00',
+                        '2020-11-25 17:24:00+00:00',
+                        '2020-11-25 17:25:00+00:00',
+                        '2020-11-25 18:23:00+00:00'
+                        ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+
+    def test_generate_multiple_next_occurences2(self):
+        """At 10:15 AM, on the last Friday of the month, 2002 through 2025
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           L ==>> This character is used to specify last day of the month or week
+        :return:
+        """
+        cron = '15 10 ? * 6L 2002-2025'
+        expected_list = ['2020-05-29 10:15:00+01:00',
+                         '2020-06-26 10:15:00+01:00',
+                         '2020-07-31 10:15:00+01:00',
+                         '2020-08-28 10:15:00+01:00',
+                         '2020-09-25 10:15:00+01:00',
+                         '2020-10-30 10:15:00+00:00',
+                         '2020-11-27 10:15:00+00:00',
+                         '2020-12-25 10:15:00+00:00',
+                         '2021-01-29 10:15:00+00:00',
+                         '2021-02-26 10:15:00+00:00'
+                         ]
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_occurences3(self):
+        """Every 3 hours
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+        :return:
+        """
+        cron = '0 */3 */1 * ? *'
+        expected_list = ['2020-12-07 18:00:00+00:00',
+                         '2020-12-07 21:00:00+00:00',
+                         '2020-12-08 00:00:00+00:00',
+                         '2020-12-08 03:00:00+00:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 12, 7, 15, 57, 37, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_occurences4(self):
+        """At 12:15 PM, only on Sunday and Monday
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+        :return:
+        """
+        cron = '15 12 ? * sun,mon *'
+        expected_list = ['2020-12-13 12:15:00+00:00',
+                         '2020-12-14 12:15:00+00:00',
+                         '2020-12-20 12:15:00+00:00',
+                         '2020-12-21 12:15:00+00:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 12, 7, 15, 57, 37, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_6(self):
+        """At 10 minutes past the hour, every 5 hours, starting at 07:00 AM, on day 7 of the month,
+           only in 2020 and 2021
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           / ==>> This character is used to specify increments.
+        :return:
+        """
+        cron = '10 7/5 7 * ? 2020,2021'
+        expected_list = ['2020-12-07 17:10:00+00:00',
+                         '2020-12-07 22:10:00+00:00',
+                         '2021-01-07 07:10:00+00:00',
+                         '2021-01-07 12:10:00+00:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 12, 7, 15, 57, 37, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+# Good test for parsing as well
+    def test_generate_multiple_next_7(self):
+        """Every minute between 10:00 PM and 10:/5 PM, on day 09 of the month, only in May,
+           only in 2020, 2021, and 2022
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           / ==>> This character is used to specify increments.
+           - ==>> This character is used to specifies ranges.
+        :return:
+        """
+        cron = '0-29/5 22 09 05 ? 2020,2021,2022'
+        expected_list = ['2021-05-09 22:00:00+01:00',
+                         '2021-05-09 22:05:00+01:00',
+                         '2021-05-09 22:10:00+01:00',
+                         '2021-05-09 22:15:00+01:00',
+                         '2021-05-09 22:20:00+01:00',
+                         '2021-05-09 22:25:00+01:00',
+                         '2022-05-09 22:00:00+01:00',
+                         '2022-05-09 22:05:00+01:00',
+                         '2022-05-09 22:10:00+01:00',
+                         '2022-05-09 22:15:00+01:00',
+                         '2022-05-09 22:20:00+01:00',
+                         '2022-05-09 22:25:00+01:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+    def test_generate_multiple_next_8(self):
+        """At 09:30 AM, between day L and 2 of the month
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           L ==>> This character is used to specify last day of the month or week
+           - ==>> This character is used to specifies ranges.
+        :return:
+        """
+        cron = '30 9 L-2 * ? *'
+        expected_list = ['2020-05-29 09:30:00+01:00',
+                         '2020-06-28 09:30:00+01:00',
+                         '2020-07-29 09:30:00+01:00',
+                         '2020-08-29 09:30:00+01:00',
+                         '2020-09-28 09:30:00+01:00',
+                         '2020-10-29 09:30:00+00:00',
+                         '2020-11-28 09:30:00+00:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_9(self):
+        """ At 09:30 AM, on the weekday nearest day 3 of the month
+            cron(Minutes Hours Day-of-month Month Day-of-week Year)
+            W ==>>This character is used to specify the weekday (Monday-Friday) nearest the given day.
+        :return:
+        """
+        cron = '30 9 3W * ? *'
+        expected_list = ['2020-08-03 09:30:00+01:00',
+                         '2020-09-03 09:30:00+01:00',
+                         '2020-10-02 09:30:00+01:00'
+                         ]
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 7, 31, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+    def test_generate_multiple_next_10(self):
+        """ At 09:30 AM, on the weekday nearest day 3 of the month
+            cron(Minutes Hours Day-of-month Month Day-of-week Year)
+            W ==>>This character is used to specify the weekday (Monday-Friday) nearest the given day.
+        :return:
+        """
+        cron = '30 9 3W * ? *'
+        expected_list = ['2020-05-04 09:30:00+01:00']
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 4, 30, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_11(self):
+        """ At 09:30 AM, on the weekday nearest day 3 of the month
+            cron(Minutes Hours Day-of-month Month Day-of-week Year)
+            W ==>>This character is used to specify the weekday (Monday-Friday) nearest the given day.
+        :return:
+        """
+        cron = '0 0 31W * ? 2020'
+        expected_list = ['2020-05-29 00:00:00+01:00',
+                         '2020-07-31 00:00:00+01:00',
+                         '2020-08-31 00:00:00+01:00']
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 4, 30, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+    def test_generate_multiple_next_12(self):
+        """ At 09:30 AM, on the weekday nearest day 3 of the month
+            cron(Minutes Hours Day-of-month Month Day-of-week Year)
+            W ==>>This character is used to specify the weekday (Monday-Friday) nearest the given day.
+        :return:
+        """
+        cron = '0 0 31W * ? *'
+        expected_list = ['2020-12-31 00:00:00+00:00',
+                         '2021-01-29 00:00:00+00:00',]
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 12, 30, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+    def test_generate_multiple_next_12(self):
+        """ On 4th and 5th minute of every hour for every day for every month and every year
+            Testing if order in the minute affects results when using the wild card ","
+            cron(Minutes Hours Day-of-month Month Day-of-week Year)
+            W ==>>This character is used to specify the weekday (Monday-Friday) nearest the given day.
+        :return:
+        """
+        cron = '5,4 * * * ? *'
+        expected_list = ['2020-04-30 23:04:00+01:00',
+                         '2020-04-30 23:05:00+01:00',
+                         '2020-05-01 00:04:00+01:00',
+                         '2020-05-01 00:05:00+01:00',
+                         '2020-05-01 01:04:00+01:00',
+                         '2020-05-01 01:05:00+01:00',
+                         '2020-05-01 02:04:00+01:00',
+                         '2020-05-01 02:05:00+01:00',
+                         '2020-05-01 03:04:00+01:00',
+                         '2020-05-01 03:05:00+01:00']
+
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 4, 30, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+
+
+    def test_generate_multiple_next_occurences13(self):
+        """At 12:15 PM, only on Sunday and Monday
+           Testing if order in the Month or Day-of-week affects results when using the wild card ","
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+        :return:
+        """
+        cron = '15 12 ? AUG,JUL mon,sun *'
+        expected_list = ['2021-07-04 12:15:00+01:00',
+                         '2021-07-05 12:15:00+01:00',
+                         '2021-07-11 12:15:00+01:00',
+                         '2021-07-12 12:15:00+01:00',
+                         '2021-07-18 12:15:00+01:00',
+                         '2021-07-19 12:15:00+01:00',
+                         '2021-07-25 12:15:00+01:00',
+                         '2021-07-26 12:15:00+01:00',
+                         '2021-08-01 12:15:00+01:00',
+                         '2021-08-02 12:15:00+01:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 12, 7, 15, 57, 37, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        # for x in range(10):
+        #     dt = cron.occurrence(dt).next()
+        #     print(f"Result: {dt}")
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+
+    def test_generate_multiple_next_14(self):
+        """Every minute between 10:00 PM and 10:/5 PM, on day 09 of the month, only in May,
+           only in 2020, 2021, and 2022
+           Testing if order in the Year affects results when using the wild card ","
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           / ==>> This character is used to specify increments.
+           - ==>> This character is used to specifies ranges.
+        :return:
+        """
+        cron = '0-29/5 22 09 05 ? 2021,2020,2022'
+        expected_list = ['2021-05-09 22:00:00+01:00',
+                         '2021-05-09 22:05:00+01:00',
+                         '2021-05-09 22:10:00+01:00',
+                         '2021-05-09 22:15:00+01:00',
+                         '2021-05-09 22:20:00+01:00',
+                         '2021-05-09 22:25:00+01:00',
+                         '2022-05-09 22:00:00+01:00',
+                         '2022-05-09 22:05:00+01:00',
+                         '2022-05-09 22:10:00+01:00',
+                         '2022-05-09 22:15:00+01:00',
+                         '2022-05-09 22:20:00+01:00',
+                         '2022-05-09 22:25:00+01:00'
+                         ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).next()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/parse_tz_tests.py
+++ b/tests/parse_tz_tests.py
@@ -1,0 +1,246 @@
+
+# -*- coding: utf-8 -*-
+
+import unittest
+import datetime
+from src.pyawscron import AWSCron
+from dateutil import tz
+
+
+class ParseCronTestCase(unittest.TestCase):
+
+    def setUp(self):
+        print(self._testMethodName)
+
+    def tearDown(self):
+        print()
+
+    def print_cron_results(self, cron_str, cron_obj):
+        print(f"Input: {cron_str}")
+        print("Result:")
+        print(f"\t{cron_obj}")
+        print(f"\tcron.minutes: {cron_obj.minutes}")
+        print(f"\tcron.hours: {cron_obj.hours}")
+        print(f"\tcron.days_of_month: {cron_obj.days_of_month}")
+        print(f"\tcron.months: {cron_obj.months}")
+        print(f"\tcron.days_of_week: {cron_obj.days_of_week}")
+        print(f"\tcron.years: {cron_obj.years}")
+
+    def test_cron_expressions1(self):
+        """
+        should parse AWS cron expressions #1
+        """
+        expected = {"minutes": [6],
+                    "hours": [4, 7, 10, 13, 16, 19, 22],
+                    "daysOfMonth": [8, 18, 19, 20, 26, 27, 28],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [], "years": [2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030]}
+        cron_str = '6 4/3 8,18-20,26-28 * ? 2020-2030'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions2(self):
+        """
+        should parse AWS cron expressions #2
+        """
+        expected = {"minutes": [15],
+                    "hours": [10],
+                    "daysOfMonth": [],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": ['L',  6],
+                    "years": [x for x in range(2002, 2025 + 1)]}
+        cron_str = '15 10 ? * 6L 2002-2025'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions3(self):
+        """
+        should parse AWS cron expressions #3
+        """
+        expected = {"minutes": [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55],
+                    "hours": [10],
+                    "daysOfMonth": [],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [2, 3, 4, 5, 6],
+                    "years": [x for x in range(1970,  2199 + 1)]}
+
+        cron_str = '*/5 10 ? * MON-FRI *'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions4(self):
+        """
+        should parse AWS cron expressions #4
+        """
+        expected = {"minutes": [0], "hours": [0, 3, 6, 9, 12, 15, 18, 21],
+                    "daysOfMonth": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                    24, 25, 26, 27, 28, 29, 30, 31],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [],
+                    "years": [x for x in range(1970,  2199 + 1)]}
+
+        cron_str = '0 */3 */1 * ? *'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions5(self):
+        """
+        should parse AWS cron expressions #5
+        """
+        expected = {"minutes": [15],
+                    "hours": [12],
+                    "daysOfMonth": [],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [1, 2],
+                    "years": [x for x in range(1970, 2199 + 1)]}
+
+        cron_str = '15 12 ? * sun,mon *'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions6(self):
+        """
+        should parse AWS cron expressions #6
+        """
+        expected = {"minutes": [10],
+                    "hours": [7, 12, 17, 22],
+                    "daysOfMonth": [7],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [],
+                    "years": [2020]}
+
+        cron_str = '10 7/5 7 * ? 2020'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+
+    def test_cron_expressions7(self):
+        """
+        should parse AWS cron expressions #7
+        """
+        expected = {"minutes": [0, 5, 10, 15, 20, 25],
+                    "hours": [22],
+                    "daysOfMonth": [9],
+                    "months": [5],
+                    "daysOfWeek": [],
+                    "years": [2020, 2021, 2022]}
+
+        cron_str = '0-29/5 22 09 05 ? 2020,2021,2022'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+    def test_cron_expressions8(self):
+        """
+        should parse AWS cron expressions #8
+        """
+        expected = {"minutes": [30],
+                    "hours": [9],
+                    "daysOfMonth": ['L', 2],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [],
+                    "years": [x for x in range(1970,  2199 + 1)]}
+
+        cron_str = '30 9 L-2 * ? *'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+    def test_cron_expressions9(self):
+        """
+        should parse AWS cron expressions #9
+        """
+        expected = {"minutes": [30],
+                    "hours": [9],
+                    "daysOfMonth": ['W', 3],
+                    "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    "daysOfWeek": [],
+                    "years": [x for x in range(1970,  2199 + 1)]}
+
+        cron_str = '30 9 3W * ? *'
+        cron_obj = AWSCron(cron_str)
+        self.print_cron_results(cron_str, cron_obj)
+        self.assertEqual(expected["minutes"], cron_obj.minutes)
+        self.assertEqual(expected["hours"], cron_obj.hours)
+        self.assertEqual(expected["daysOfMonth"], cron_obj.days_of_month)
+        self.assertEqual(expected["months"], cron_obj.months)
+        self.assertEqual(expected["daysOfWeek"], cron_obj.days_of_week)
+        self.assertEqual(expected["years"], cron_obj.years)
+
+    def test_cron_expressions10(self):
+        """
+        Tested changes to get_days_of_month_from_days_of_week(), where the year rolls over and the month rolls over into a month that has less than 31 days.
+        """
+        cron_str = '0 9 ? * 2 *'
+        expected_list= ['2022-01-03 09:00:00+00:00',
+                        '2022-01-10 09:00:00+00:00',
+                        '2022-01-17 09:00:00+00:00',
+                        '2022-01-24 09:00:00+00:00',
+                        '2022-01-31 09:00:00+00:00',
+                        '2022-02-07 09:00:00+00:00',
+                        '2022-02-14 09:00:00+00:00',
+                        '2022-02-21 09:00:00+00:00',
+                        '2022-02-28 09:00:00+00:00',
+                        '2022-03-07 09:00:00+00:00'
+                        ]
+        cron = AWSCron(cron_str)
+        dt = datetime.datetime(2021, 12, 31, 21, 0, 0, tzinfo=tz.gettz('Europe/London'))
+        self.print_cron_results(cron_str, cron)                        
+        results = []        
+        for expected in expected_list:
+            dt = cron.occurrence(dt).next()
+            self.assertEqual(expected, str(dt))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/prev_tz_tests.py
+++ b/tests/prev_tz_tests.py
@@ -1,0 +1,61 @@
+
+# -*- coding: utf-8 -*-
+
+import unittest
+import datetime
+from src.pyawscron import AWSCron
+from dateutil import tz
+
+class PrevTestCase(unittest.TestCase):
+
+
+    def setUp(self):
+        print(self._testMethodName)
+
+
+    def tearDown(self):
+        pass
+
+    def test_generate_multiple_prev_occurences1(self):
+        """At 23, 24, and 25 minutes past the hour, at 05:00 PM and 06:00 PM,
+           on day 25 of the month, every 4 months, March through December,
+           only in 2019, 2020, 2021, 2023, and 2028
+           cron(Minutes Hours Day-of-month Month Day-of-week Year)
+           / ==>> This character is used to specify increments.
+        :return:
+        """
+        cron = '23,24,25 17,18 25 MAR/4 ? 2019,2020,2021,2023,2028'
+
+        expected_list= ['2020-03-25 18:25:00+00:00',
+                        '2020-03-25 18:24:00+00:00',
+                        '2020-03-25 18:23:00+00:00',
+                        '2020-03-25 17:25:00+00:00',
+                        '2020-03-25 17:24:00+00:00',
+                        '2020-03-25 17:23:00+00:00',
+
+                        '2019-11-25 18:25:00+00:00',
+                        '2019-11-25 18:24:00+00:00',
+                        '2019-11-25 18:23:00+00:00',
+                        '2019-11-25 17:25:00+00:00',
+                        '2019-11-25 17:24:00+00:00',
+                        '2019-11-25 17:23:00+00:00',
+                        
+                        '2019-07-25 18:25:00+01:00',
+                        '2019-07-25 18:24:00+01:00',
+                        '2019-07-25 18:23:00+01:00',
+                        '2019-07-25 17:25:00+01:00',
+                        '2019-07-25 17:24:00+01:00',
+                        '2019-07-25 17:23:00+01:00'
+                        ]
+        cron = AWSCron(cron)
+        dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=tz.gettz('Europe/London'))
+        results = []
+        for expected in expected_list:
+            print(f"Input {cron}, occurrence: {dt}")
+            dt = cron.occurrence(dt).prev()
+            results.append(str(dt))
+            print(f"Result: {dt}\tExpected: {expected}\n")
+            self.assertEqual(expected, str(dt))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have been playing with support for being able to specify datetime objects with a specified timezone other than UTC. Prior to AWS Eventbridge Scheduler, timezones were not really used by many services. As things mature, specifying timezone which automatically handle DST is really beneficial.

Apologies if this PR is somewhat incomplete. I'm no python expert, but these changes seem quite reliable for my use case. Please consider implementing these changes in pyawscron

Fixes #62